### PR TITLE
Fix NREs breaking bill menu window

### DIFF
--- a/Source/CommonSense14/CommonSense/TextChanges.cs
+++ b/Source/CommonSense14/CommonSense/TextChanges.cs
@@ -143,7 +143,7 @@ namespace CommonSense
                 {
                     HashSet<StuffCategoryDef> l = new HashSet<StuffCategoryDef>();
                     foreach (var c in (allowAllWhoCanMake)) 
-                        if(c != null) 
+                        if(c != null && c.stuffCategories != null) 
                             l.AddRange(c.stuffCategories);
                     __result = "";
                     foreach (var def in l)


### PR DESCRIPTION
I've no idea why or how this would be null, but checking for it does keep it from breaking the rest of the menu, even if the ingredients list is not displayed properly.