### PR TITLE
explicitly pass bool to invoke of DetermineNextJob

### DIFF
--- a/Source/CommonSense15/CommonSense/OpportunisticTasks.cs
+++ b/Source/CommonSense15/CommonSense/OpportunisticTasks.cs
@@ -233,12 +233,16 @@ namespace CommonSense
                 if (__instance == null || __instance._pawn == null || !__instance._pawn.IsColonistPlayerControlled || __instance.curJob == null)
                     return true;
 
+                //Log.Message("beginning endCurrentJob common sense for " + __instance.curJob);
+
                 if (Settings.fun_police && __instance._pawn.needs.joy != null && __instance._pawn.needs.joy.CurLevel > 0.95f)
                 {
                     CompJoyToppedOff c = __instance._pawn.TryGetComp<CompJoyToppedOff>();
                     if (c != null)
                         c.JoyToppedOff = true;
                 }
+
+                //Log.Message("did fun bit");
 
                 Job job = null;
                 if (Settings.clean_before_work && condition == JobCondition.Succeeded && __instance.jobQueue != null
@@ -247,24 +251,31 @@ namespace CommonSense
                     job = MakeCleaningJob(__instance._pawn, __instance.curJob.targetA, Settings.op_clean_num);
                 }
 
+                //Log.Message("did before work bit");
+
                 if (Settings.clean_after_tending && condition == JobCondition.Succeeded && __instance.jobQueue != null
                     && __instance.jobQueue.Count == 0 && ProperJob(__instance.curJob, __instance._pawn, JobDefOf.TendPatient))
                 {
+                    //Log.Message("creating post tend clean job");
                     ThinkTreeDef thinkTree = null;
                     MethodInfo mi = AccessTools.Method(typeof(Pawn_JobTracker), "DetermineNextJob");
-                    ThinkResult thinkResult = (ThinkResult)mi.Invoke(__instance, new object[] { thinkTree });
+                    ThinkResult thinkResult = (ThinkResult)mi.Invoke(__instance, new object[] { thinkTree, false });
+                    //Log.Message("using think result: "+thinkResult);
                     if (ProperJob(thinkResult.Job, __instance._pawn, JobDefOf.TendPatient))
                     {
                         Pawn pawn = (Pawn)thinkResult.Job.targetA.Thing;
                         if (pawn.GetRoom() == __instance.curJob.targetA.Thing.GetRoom() || (HealthUtility.TicksUntilDeathDueToBloodLoss(pawn) / 2500f) < 6)
                             return true;
                     }
-
+                    //Log.Message("making job");
                     job = MakeCleaningJob(__instance._pawn, __instance.curJob.targetA, Settings.doc_clean_num);
                 }
                 //
                 if (job != null)
+                {
+                    //Log.Message("queing job");
                     __instance.jobQueue.EnqueueFirst(job);
+                }
                 //
                 return true;
             }


### PR DESCRIPTION
In my current playthrough, I was experiencing errors using alongside Priority Treatment Ressurected (I am the developer of that mod). The post-tend cleaning attempt would fail with the following error:

`Exception in CheckCurrentToilEndOrFail for pawn Mekkie driver=JobDriver_TendPatient (toilIndex=5) driver.job=(TendPatient (Job_927296) A = Thing_Human1847)
System.Reflection.TargetParameterCountException: Number of parameters specified does not match the expected number.
[Ref A53F251A]
 at System.Reflection.MonoMethod.ConvertValues (System.Reflection.Binder binder, System.Object[] args, System.Reflection.ParameterInfo[] pinfo, System.Globalization.CultureInfo culture, System.Reflection.BindingFlags invokeAttr) [0x00016] in <eae584ce26bc40229c1b1aa476bfa589>:0 
 at System.Reflection.MonoMethod.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x00011] in <eae584ce26bc40229c1b1aa476bfa589>:0 
 at System.Reflection.MethodBase.Invoke (System.Object obj, System.Object[] parameters) [0x00000] in <eae584ce26bc40229c1b1aa476bfa589>:0 
 at CommonSense.OpportunisticTasks+Pawn_JobTracker_EndCurrentJob_CommonSensePatch.Prefix (CommonSense.OpportunisticTasks+Pawn_JobTracker_Crutch __instance, Verse.AI.JobCondition condition) [0x0012a] in <bf2cc694fb984db0b4b4394ec29b0d3b>:0 
 at Verse.AI.Pawn_JobTracker.EndCurrentJob (Verse.AI.JobCondition condition, System.Boolean startNewJob, System.Boolean canReturnToPool) [0x00017] in <9b17790b066e46d08be4026d65926375>:0 
     - PREFIX net.avilmask.rimworld.mod.CommonSense: Boolean CommonSense.OpportunisticTasks+Pawn_JobTracker_EndCurrentJob_CommonSensePatch:Prefix(Pawn_JobTracker_Crutch __instance, JobCondition condition)
     - PREFIX OskarPotocki.VanillaTraitsExpanded: Void VanillaTraitsExpanded.EndCurrentJobPatch:Prefix(Pawn ___pawn)
 at Verse.AI.JobDriver.EndJobWith (Verse.AI.JobCondition condition) [0x00028] in <9b17790b066e46d08be4026d65926375>:0 
 at Verse.AI.JobDriver.CheckCurrentToilEndOrFail () [0x0009f] in <9b17790b066e46d08be4026d65926375>:0 
     - TRANSPILER net.pardeike.rimworld.lib.harmony: IEnumerable`1 VisualExceptions.ExceptionsAndActivatorHandler:Transpiler(IEnumerable`1 instructions, MethodBase original)
UnityEngine.StackTraceUtility:ExtractStackTrace ()
(wrapper dynamic-method) MonoMod.Utils.DynamicMethodDefinition:Verse.Log.Error_Patch3 (string)
Verse.AI.JobUtility:TryStartErrorRecoverJob (Verse.Pawn,string,System.Exception,Verse.AI.JobDriver)
(wrapper dynamic-method) MonoMod.Utils.DynamicMethodDefinition:Verse.AI.JobDriver.CheckCurrentToilEndOrFail_Patch0 (Verse.AI.JobDriver)
(wrapper dynamic-method) MonoMod.Utils.DynamicMethodDefinition:Verse.AI.JobDriver.TryActuallyStartNextToil_Patch0 (Verse.AI.JobDriver)
Verse.AI.JobDriver:ReadyForNextToil ()
(wrapper dynamic-method) MonoMod.Utils.DynamicMethodDefinition:Verse.AI.JobDriver.TryActuallyStartNextToil_Patch0 (Verse.AI.JobDriver)
Verse.AI.JobDriver:ReadyForNextToil ()
(wrapper dynamic-method) MonoMod.Utils.DynamicMethodDefinition:Verse.AI.JobDriver.DriverTick_Patch0 (Verse.AI.JobDriver)
Verse.AI.Pawn_JobTracker:JobTrackerTick ()
(wrapper dynamic-method) MonoMod.Utils.DynamicMethodDefinition:Verse.Pawn.Tick_Patch1 (Verse.Pawn)
(wrapper dynamic-method) MonoMod.Utils.DynamicMethodDefinition:Verse.TickList.Tick_Patch0 (Verse.TickList)
(wrapper dynamic-method) MonoMod.Utils.DynamicMethodDefinition:Verse.TickManager.DoSingleTick_Patch3 (Verse.TickManager)
Verse.TickManager:TickManagerUpdate ()
(wrapper dynamic-method) MonoMod.Utils.DynamicMethodDefinition:Verse.Game.UpdatePlay_Patch1 (Verse.Game)
(wrapper dynamic-method) MonoMod.Utils.DynamicMethodDefinition:Verse.Root_Play.Update_Patch0 (Verse.Root_Play)`

I logged to find the problem and tried explicitly passing bool to the DetermineNextJob invoke and that removed the error successfully, and the pawn cleaned the room after the tend. I also wrapped the final `return job` bit in { }, not sure how it worked without it (i'm no c# expert).

I'm not sure why that bool is necessary, or why it didn't come up before. Happy to do more exploration if you think it necessary.