### PR TITLE
do not use random coordinates as a hack to store cleaning progress (#53)

### DIFF
--- a/Source/CommonSense16/CommonSense/CommonSense.csproj
+++ b/Source/CommonSense16/CommonSense/CommonSense.csproj
@@ -66,6 +66,7 @@
   <ItemGroup>
     <Compile Include="CleanOnOpportunity.cs" />
     <Compile Include="DoCleanComp.cs" />
+    <Compile Include="JobDriverData.cs" />
     <Compile Include="JobDriver_IngestPatches.cs" />
     <Compile Include="JobDriver_MeditatePatches.cs" />
     <Compile Include="JobDriver_SocialRelaxPatches.cs" />

--- a/Source/CommonSense16/CommonSense/JobDriverData.cs
+++ b/Source/CommonSense16/CommonSense/JobDriverData.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using Verse;
+using Verse.AI;
+using HarmonyLib;
+
+namespace CommonSense
+{
+    // Store mod's per-JobDriver data. Saving/loading done as part of the JobDriver's ExposeData() call.
+    public class JobDriverData
+    {
+        public float cleaningWorkDone;
+        public float totalCleaningWorkDone;
+        public float totalCleaningWorkRequired;
+
+        private static Dictionary< JobDriver, JobDriverData > dict = new Dictionary< JobDriver, JobDriverData >();
+
+        public static JobDriverData Get(JobDriver driver)
+        {
+            JobDriverData data;
+            if( dict.TryGetValue(driver, out data))
+                return data;
+            data = new JobDriverData();
+            dict[ driver ] = data;
+            return data;
+        }
+
+        public void ExposeData()
+        {
+            Scribe_Values.Look(ref cleaningWorkDone, "CommonSense.cleaningWorkDone", 0f);
+            Scribe_Values.Look(ref totalCleaningWorkDone, "CommonSense.totalCleaningWorkDone", 0f);
+            Scribe_Values.Look(ref totalCleaningWorkRequired, "CommonSense.totalCleaningWorkRequired", 0f);
+        }
+
+        public static void ClearAll()
+        {
+            dict.Clear();
+        }
+    }
+
+    // Clean the data when starting a different game.
+    [HarmonyPatch(typeof(Game))]
+    public static class Game_Patch
+    {
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(InitNewGame))]
+        internal static void InitNewGame()
+        {
+            JobDriverData.ClearAll();
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(LoadGame))]
+        internal static void LoadGame()
+        {
+            JobDriverData.ClearAll();
+        }
+    }
+}

--- a/Source/CommonSense16/CommonSense/JobDriverData.cs
+++ b/Source/CommonSense16/CommonSense/JobDriverData.cs
@@ -25,6 +25,11 @@ namespace CommonSense
             return data;
         }
 
+        public static void Clear(JobDriver driver)
+        {
+            dict.Remove(driver);
+        }
+
         public void ExposeData()
         {
             Scribe_Values.Look(ref cleaningWorkDone, "CommonSense.cleaningWorkDone", 0f);

--- a/Source/CommonSense16/CommonSense/JobDriver_IngestPatches.cs
+++ b/Source/CommonSense16/CommonSense/JobDriver_IngestPatches.cs
@@ -54,6 +54,7 @@ namespace CommonSense
         {
             Toil toil = new Toil();
             JobDriverData data = JobDriverData.Get(driver);
+            driver.AddFinishAction( (JobCondition) => JobDriverData.Clear(driver));
             toil.initAction = delegate ()
             {
                 Filth filth = toil.actor.jobs.curJob.GetTarget(filthListIndex).Thing as Filth;

--- a/Source/CommonSense16/CommonSense/JobDriver_SocialRelaxPatches.cs
+++ b/Source/CommonSense16/CommonSense/JobDriver_SocialRelaxPatches.cs
@@ -135,6 +135,7 @@ namespace CommonSense
                 driver.job.GetTargetQueue(TargetIndex.B).Add(new IntVec3(0, 0, 0));
                 Toil clean = new Toil();
                 JobDriverData data = JobDriverData.Get(driver);
+                driver.AddFinishAction( (JobCondition) => JobDriverData.Clear(driver));
                 clean.initAction = delegate ()
                 {
                     Filth filth = clean.actor.jobs.curJob.GetTarget(TargetIndex.A).Thing as Filth;

--- a/Source/CommonSense16/CommonSense/JobGiver_DoBIll_Rework.cs
+++ b/Source/CommonSense16/CommonSense/JobGiver_DoBIll_Rework.cs
@@ -375,6 +375,7 @@ namespace CommonSense
                 yield return Toils_Goto.GotoThing(TargetIndex.A, PathEndMode.Touch).JumpIfDespawnedOrNullOrForbidden(TargetIndex.A, CleanFilthList).JumpIfOutsideHomeArea(TargetIndex.A, CleanFilthList);
                 Toil clean = ToilMaker.MakeToil("CleanBillPlace");
                 JobDriverData data = JobDriverData.Get(__instance);
+                __instance.AddFinishAction( (JobCondition) => JobDriverData.Clear(__instance));
                 clean.initAction = delegate ()
                 {
                     Filth filth = clean.actor.jobs.curJob.GetTarget(TargetIndex.A).Thing as Filth;


### PR DESCRIPTION
Make this more JobDriver_CleanFilth-like (where this was presumably copied from). Since RimWorld doesn't make it easy to add extra data to its classes, make an extra Dictionary-based class that stores the JobDriver-related data, and saving/loading of the data is done as part of the relevant JobDriver ExposeData().

This not strictly backwards compatible with previous saves in case a save is done while the cleaning is in progress, but the code handles that case fine (progress is reset and the infinity resulting from the division by zero makes progressbar full until the cleaning finishes).