### PR TITLE
Fix for WorkBenchAuto having ingredients HauledTo instead of Inserted

### DIFF
--- a/Source/CommonSense14/CommonSense/JobGiver_DoBIll_Rework.cs
+++ b/Source/CommonSense14/CommonSense/JobGiver_DoBIll_Rework.cs
@@ -50,7 +50,7 @@ namespace CommonSense
                 }
                 return false;
             });
-            bool placeInBillGiver = __instance.BillGiver is Building_MechGestator;
+            bool placeInBillGiver = __instance.BillGiver is Building_WorkTableAutonomous;
             Toil gotoBillGiver = Toils_Goto.GotoThing(TargetIndex.A, PathEndMode.InteractionCell);
             Toil toil = ToilMaker.MakeToil("MakeNewToils");
             toil.initAction = delegate ()
@@ -346,7 +346,7 @@ namespace CommonSense
             }
             else
             {
-                foreach (Toil toil2 in JobDriver_DoBill.CollectIngredientsToils(TargetIndex.B, TargetIndex.A, TargetIndex.C, false, true, __instance.BillGiver is Building_MechGestator))
+                foreach (Toil toil2 in JobDriver_DoBill.CollectIngredientsToils(TargetIndex.B, TargetIndex.A, TargetIndex.C, false, true, placeInBillGiver))
                 {
                     yield return toil2;
                     if (toil2.debugName == "JumpIfTargetInsideBillGiver")

--- a/Source/CommonSense15/CommonSense/JobGiver_DoBIll_Rework.cs
+++ b/Source/CommonSense15/CommonSense/JobGiver_DoBIll_Rework.cs
@@ -55,7 +55,7 @@ namespace CommonSense
                 return false;
             });
 
-            bool placeInBillGiver = __instance.BillGiver is Building_MechGestator;
+            bool placeInBillGiver = __instance.BillGiver is Building_WorkTableAutonomous;
             Toil gotoBillGiver = Toils_Goto.GotoThing(TargetIndex.A, PathEndMode.InteractionCell);
             Toil toil = ToilMaker.MakeToil("MakeNewToils");
             toil.initAction = delegate ()
@@ -338,7 +338,7 @@ namespace CommonSense
             }
             else
             {
-                foreach (Toil toil2 in JobDriver_DoBill.CollectIngredientsToils(TargetIndex.B, TargetIndex.A, TargetIndex.C, false, true, __instance.BillGiver is Building_WorkTableAutonomous))
+                foreach (Toil toil2 in JobDriver_DoBill.CollectIngredientsToils(TargetIndex.B, TargetIndex.A, TargetIndex.C, false, true, placeInBillGiver))
                 {
                     yield return toil2;
                     if (toil2.debugName == "JumpIfTargetInsideBillGiver")

--- a/Source/CommonSense16/CommonSense/JobGiver_DoBIll_Rework.cs
+++ b/Source/CommonSense16/CommonSense/JobGiver_DoBIll_Rework.cs
@@ -313,7 +313,7 @@ namespace CommonSense
                 return false;
             });
 
-            bool placeInBillGiver = __instance.BillGiver is Building_MechGestator;
+            bool placeInBillGiver = __instance.BillGiver is Building_WorkTableAutonomous;
             Toil gotoBillGiver = Toils_Goto.GotoThing(TargetIndex.A, PathEndMode.InteractionCell);
             Toil toil = ToilMaker.MakeToil("MakeNewToils");
             toil.initAction = delegate ()
@@ -375,7 +375,7 @@ namespace CommonSense
             }
             else
             {
-                foreach (Toil toil2 in JobDriver_DoBill.CollectIngredientsToils(TargetIndex.B, TargetIndex.A, TargetIndex.C, false, true, __instance.BillGiver is Building_WorkTableAutonomous))
+                foreach (Toil toil2 in JobDriver_DoBill.CollectIngredientsToils(TargetIndex.B, TargetIndex.A, TargetIndex.C, false, true, placeInBillGiver))
                 {
                     yield return toil2;
                 }


### PR DESCRIPTION
Fix for #61, tested on a new WorkTableAutonomous subclass in v1.5